### PR TITLE
todoリストの並び替え実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "Memori_TodoApp",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
         "@prisma/client": "^5.20.0",
         "@supabase/supabase-js": "^2.45.4",
         "@types/node-fetch": "^2.6.12",
@@ -18,9 +20,9 @@
         "isomorphic-fetch": "^3.0.0",
         "next": "14.2.14",
         "node-fetch": "^3.3.2",
-        "react": "^18",
+        "react": "^18.3.1",
         "react-calendar": "^5.0.0",
-        "react-dom": "^18",
+        "react-dom": "^18.3.1",
         "react-hook-form": "^7.54.2",
         "react-hot-toast": "^2.4.1",
         "react-icons": "^5.3.0",
@@ -187,6 +189,55 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/runtime": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "postcss": "^8",
         "prisma": "^5.20.0",
         "tailwindcss": "^3.4.17",
+        "tsx": "^4.20.2",
         "typescript": "^5"
       }
     },
@@ -351,6 +352,406 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
       "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg=="
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.5.tgz",
+      "integrity": "sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.5.tgz",
+      "integrity": "sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.5.tgz",
+      "integrity": "sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.5.tgz",
+      "integrity": "sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.5.tgz",
+      "integrity": "sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.5.tgz",
+      "integrity": "sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.5.tgz",
+      "integrity": "sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.5.tgz",
+      "integrity": "sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.5.tgz",
+      "integrity": "sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.5.tgz",
+      "integrity": "sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.5.tgz",
+      "integrity": "sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.5.tgz",
+      "integrity": "sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.5.tgz",
+      "integrity": "sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.5.tgz",
+      "integrity": "sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.5.tgz",
+      "integrity": "sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.5.tgz",
+      "integrity": "sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.5.tgz",
+      "integrity": "sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.5.tgz",
+      "integrity": "sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.5.tgz",
+      "integrity": "sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.5.tgz",
+      "integrity": "sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.5.tgz",
+      "integrity": "sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.5.tgz",
+      "integrity": "sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.5.tgz",
+      "integrity": "sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.5.tgz",
+      "integrity": "sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.5.tgz",
+      "integrity": "sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -2694,6 +3095,46 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
+      "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.5",
+        "@esbuild/android-arm": "0.25.5",
+        "@esbuild/android-arm64": "0.25.5",
+        "@esbuild/android-x64": "0.25.5",
+        "@esbuild/darwin-arm64": "0.25.5",
+        "@esbuild/darwin-x64": "0.25.5",
+        "@esbuild/freebsd-arm64": "0.25.5",
+        "@esbuild/freebsd-x64": "0.25.5",
+        "@esbuild/linux-arm": "0.25.5",
+        "@esbuild/linux-arm64": "0.25.5",
+        "@esbuild/linux-ia32": "0.25.5",
+        "@esbuild/linux-loong64": "0.25.5",
+        "@esbuild/linux-mips64el": "0.25.5",
+        "@esbuild/linux-ppc64": "0.25.5",
+        "@esbuild/linux-riscv64": "0.25.5",
+        "@esbuild/linux-s390x": "0.25.5",
+        "@esbuild/linux-x64": "0.25.5",
+        "@esbuild/netbsd-arm64": "0.25.5",
+        "@esbuild/netbsd-x64": "0.25.5",
+        "@esbuild/openbsd-arm64": "0.25.5",
+        "@esbuild/openbsd-x64": "0.25.5",
+        "@esbuild/sunos-x64": "0.25.5",
+        "@esbuild/win32-arm64": "0.25.5",
+        "@esbuild/win32-ia32": "0.25.5",
+        "@esbuild/win32-x64": "0.25.5"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -3353,6 +3794,20 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -6162,6 +6617,25 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+    },
+    "node_modules/tsx": {
+      "version": "4.20.2",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.2.tgz",
+      "integrity": "sha512-He0ZWr41gLa4vD30Au3yuwpe0HXaCZbclvl8RBieUiJ9aFnPMWUPIyvw3RU8+1Crjfcrauvitae2a4tUzRAGsw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "postcss": "^8",
     "prisma": "^5.20.0",
     "tailwindcss": "^3.4.17",
+    "tsx": "^4.20.2",
     "typescript": "^5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "@prisma/client": "^5.20.0",
     "@supabase/supabase-js": "^2.45.4",
     "@types/node-fetch": "^2.6.12",
@@ -19,9 +21,9 @@
     "isomorphic-fetch": "^3.0.0",
     "next": "14.2.14",
     "node-fetch": "^3.3.2",
-    "react": "^18",
+    "react": "^18.3.1",
     "react-calendar": "^5.0.0",
-    "react-dom": "^18",
+    "react-dom": "^18.3.1",
     "react-hook-form": "^7.54.2",
     "react-hot-toast": "^2.4.1",
     "react-icons": "^5.3.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,8 +16,8 @@ model Users {
   userName       String
   supabaseUserId String         @unique
   themeColorId   ThemeColorId
- startOfWeek    StartOfWeek     @default(iso8601)
- createdAt      DateTime       @default(now())
+  startOfWeek    StartOfWeek    @default(iso8601)
+  createdAt      DateTime       @default(now())
   updatedAt      DateTime       @updatedAt
   calendars      Calendar[]
   routineWorks   RoutineWork[]
@@ -27,10 +27,12 @@ model Users {
 
   @@map("Users")
 }
+
 enum StartOfWeek {
   gregory
   iso8601
 }
+
 enum ThemeColorId {
   Theme01
   Theme02
@@ -92,6 +94,7 @@ model TodoItems {
   todoGroupId Int
   toDoItem    String
   isChecked   Boolean
+  sortOrder   Int?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 

--- a/scripts/updateSortOrder.ts
+++ b/scripts/updateSortOrder.ts
@@ -1,0 +1,35 @@
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const todoGroups = await prisma.todoGroup.findMany({
+    include: {
+      toDoItems: {
+        orderBy: { createdAt: "asc" },
+      },
+    },
+  });
+
+  for (const group of todoGroups) {
+    console.log(`Updating todoGroupId: ${group.id}`);
+
+    for (let i = 0; i < group.toDoItems.length; i++) {
+      const item = group.toDoItems[i];
+      await prisma.todoItems.update({
+        where: { id: item.id },
+        data: { sortOrder: i + 1 },
+      });
+    }
+  }
+
+  console.log("✅ All sortOrders have been updated.");
+}
+
+main()
+  .catch((e) => {
+    console.error("❌ Error:", e);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/app/(members)/todo/_components/Items.tsx
+++ b/src/app/(members)/todo/_components/Items.tsx
@@ -54,7 +54,13 @@ const Items: React.FC<Props> = ({
                 // フォーカスが外れたら保存
               }}
               placeholder="新しいタスクを入力"
-              className="px-2 py-1 border-b-2 w-[85%] focus:outline-none"
+              className={`px-2 py-1 border-b-2 w-[85%] focus:outline-none ${
+                toDoItem.length >= 20
+                  ? "text-[10px]"
+                  : toDoItem.length >= 14
+                  ? "text-[13px]"
+                  : "text-[1rem]"
+              }`}
             />
           </div>
 

--- a/src/app/(members)/todo/_components/Items.tsx
+++ b/src/app/(members)/todo/_components/Items.tsx
@@ -1,6 +1,6 @@
 import { CreateTodoItemRequestBody } from "@/app/_type/Todo";
 import React, { RefObject } from "react";
-import { BsTrash3Fill } from "react-icons/bs"; // アイコンをインポート
+import { BsTrash3Fill } from "react-icons/bs";
 
 interface Props {
   id: number;

--- a/src/app/(members)/todo/_components/SortableItem.tsx
+++ b/src/app/(members)/todo/_components/SortableItem.tsx
@@ -1,0 +1,39 @@
+"use client";
+import React from "react";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { TbHandGrab } from "react-icons/tb";
+
+type Props = {
+  id: number;
+  toDoItem: string;
+};
+
+export const SortableItem: React.FC<Props> = ({ id, toDoItem }) => {
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({ id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      className="w-[80%] mx-auto flex items-center p-2 border-b text-text_button hover:bg-gray-100 cursor-grab active:cursor-grabbing"
+    >
+      <span
+        {...listeners}
+        className="cursor-grab mr-2 text-3xl text-indigo-500"
+      >
+        <TbHandGrab />
+      </span>
+      <span className="">{toDoItem}</span>
+    </li>
+  );
+};
+
+// export default SortableItem;

--- a/src/app/(members)/todo/_hooks/useControlTodo.tsx
+++ b/src/app/(members)/todo/_hooks/useControlTodo.tsx
@@ -313,6 +313,7 @@ export const useTodo = () => {
     todoItems,
     postItem,
     newItem,
+    setNewItem,
     addPostNewItem,
     setPostTodoTitle,
     postTodoTitle,

--- a/src/app/(members)/todo/_hooks/useControlTodo.tsx
+++ b/src/app/(members)/todo/_hooks/useControlTodo.tsx
@@ -137,6 +137,7 @@ export const useTodo = () => {
       todoGroupId: activeTabId,
       toDoItem: postTodoTitle,
       isChecked: false,
+      sortOrder: todoItems.length + 1,
     };
 
     try {
@@ -344,11 +345,11 @@ export const useTodo = () => {
       return toast(
         <div>
           <p className="pb-2">🏷️並べ替えモード</p>
-          <div className="flex items-center">
-            <p className="w-[1.5rem] text-3xl pt-2 pb-0">
+          <div className="flex items-center gap-1">
+            <p className="w-[1.5rem] text-3xl pb-0">
               <TbHandGrab />
             </p>
-            <p>ドラッグして変更</p>
+            <p>をドラッグして変更</p>
           </div>
         </div>
       );
@@ -356,7 +357,7 @@ export const useTodo = () => {
 
     const reordered = todoItems.map((item, index) => ({
       id: item.id,
-      sortOrder: index, // 0から順番に
+      sortOrder: index + 1, // 0から順番に
     }));
 
     toast("🏷️並べ替えモードを終了");

--- a/src/app/(members)/todo/_hooks/useControlTodo.tsx
+++ b/src/app/(members)/todo/_hooks/useControlTodo.tsx
@@ -299,6 +299,42 @@ export const useTodo = () => {
     }
   };
 
+  //////dndkit
+  // useControlTodo.tsx の中にこんな感じの関数を追加
+  // const updateTodoOrder = async(sortedItem: CreateTodoItemRequestBody[]) => {
+  //   const token = (await supabase.auth.getSession()).data?.session?.access_token;
+
+  //   // 仮のidを付与する（本来はサーバーから取得するidを使うべき）
+  //   const convertedOrder = sortedItem.map((item, idx) => ({
+  //     ...item,
+  //     id: todoItems[idx]?.id ?? idx + 1, // 既存のidがあれば使い、なければ仮id
+  //   }));
+  //   setTodoItems(convertedOrder);
+  //   // ここでサーバーに順番更新リクエストを投げる処理も入れてOK
+  // };
+
+  const updateTodoOrder = async (sortedItems: TodoItem[]) => {
+    const token = (await supabase.auth.getSession()).data?.session
+      ?.access_token;
+
+    const reordered = sortedItems.map((item, index) => ({
+      id: item.id,
+      sortOrder: index, // 0から順番に
+    }));
+
+    await fetch(`/api/todoItems/${activeTabId}/reorder`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: token || "",
+      },
+      body: JSON.stringify({ items: reordered }),
+    });
+
+    // stateも更新（必要なら）
+    setTodoItems(sortedItems);
+  };
+
   return {
     deleteItem,
     saveItem,
@@ -317,5 +353,6 @@ export const useTodo = () => {
     addPostNewItem,
     setPostTodoTitle,
     postTodoTitle,
+    updateTodoOrder, // dndkit用の関数を返す
   };
 };

--- a/src/app/(members)/todo/page.tsx
+++ b/src/app/(members)/todo/page.tsx
@@ -1,11 +1,28 @@
 "use client";
-import React from "react";
+import React, { useState } from "react";
 import Tabs from "./_components/Tabs";
 import Navigation from "../../_components/Navigation";
 import Items from "./_components/Items";
 import PlusButton from "../../_components/PlusButton";
 import { Toaster } from "react-hot-toast";
 import { useTodo } from "./_hooks/useControlTodo";
+// import { TbHandGrab } from "react-icons/tb";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+// import SortableItem from "./_components/SortableItem";
+import { SortableItem } from "./_components/SortableItem";
 
 const Page: React.FC = () => {
   const {
@@ -26,65 +43,109 @@ const Page: React.FC = () => {
     postTodoTitle,
     setPostTodoTitle,
     addPostNewItem,
+    updateTodoOrder,
   } = useTodo();
-
+  const [isSortMode, setIsSortMode] = useState(false);
   return (
-    <div>
-      <h2 className="text-white text-2xl text-center">ToDo.</h2>
-      <Tabs
-        todoGroups={todoGroups}
-        activeTabId={activeTabId}
-        setActiveTabId={setActiveTabId}
-      />
-      <ul className="bg-white m-auto max-w-md w-[95%] pt-6 pb-16 min-h-svh">
-        {todoItems
-          .filter((item) => item.todoGroupId === activeTabId)
-          .map((item) => (
-            <Items
-              key={item.id}
-              id={item.id}
-              toDoItem={item.toDoItem}
-              isChecked={item.isChecked}
-              toggleCompletion={toggleCompletion}
-              inputRef={inputRef}
-              updateItem={updateItem}
-              saveItem={saveItem}
-              todoItems={todoItems}
-              deleteItem={deleteItem}
-              postItem={postItem}
-            />
-          ))}
-        {newItem && (
-          <li className="flex w-[95%] m-auto py-1 text-lg text-text_button">
-            <div className="flex items-center justify-center w-[20rem]  ml-4">
-              <button
-                className={`w-7 h-7 rounded-full border-2 flex justify-center items-center "border-text_button`}
-              >
-                <span className="text-white ">✓</span>
-              </button>
-              <input
-                placeholder="入力(フォーカスを外すと登録)"
-                ref={inputRef} // useRefで作成したrefをここに設定
-                type="text"
-                value={postTodoTitle}
-                onChange={(e) => setPostTodoTitle(e.target.value)}
-                // onBlur={addPostNewItem}
-                onBlur={() =>
-                  postTodoTitle.trim() === ""
-                    ? (setNewItem(false), setPostTodoTitle(""))
-                    : addPostNewItem()
-                }
-                className="px-2 py-1 border-b-2 w-[85%] focus:outline-none "
-              />
-            </div>
-          </li>
-        )}
-      </ul>
-
-      <PlusButton handleAddEvent={addEmptyItem} />
-      <Navigation />
-      <Toaster position="top-center" />
-    </div>
+    <>
+      <div>
+        <h2 className="text-white text-2xl text-center">ToDo.</h2>
+        <Tabs
+          todoGroups={todoGroups}
+          activeTabId={activeTabId}
+          setActiveTabId={setActiveTabId}
+        />
+        <DndContext
+          sensors={useSensors(
+            useSensor(PointerSensor),
+            useSensor(KeyboardSensor, {
+              coordinateGetter: sortableKeyboardCoordinates,
+            })
+          )}
+          collisionDetection={closestCenter}
+          onDragEnd={({ active, over }) => {
+            if (!over || active.id === over.id) return;
+            const oldIndex = todoItems.findIndex(
+              (item) => item.id === active.id
+            );
+            const newIndex = todoItems.findIndex((item) => item.id === over.id);
+            const sorted = arrayMove(todoItems, oldIndex, newIndex);
+            updateTodoOrder(sorted); // useTodo から取得済み
+          }}
+        >
+          <SortableContext
+            items={todoItems.map((item) => item.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            <ul className="bg-white m-auto max-w-md w-[95%] pt-6 pb-16 min-h-svh">
+              {todoItems
+                .filter((item) => item.todoGroupId === activeTabId)
+                .map((item) =>
+                  isSortMode ? (
+                    <SortableItem
+                      key={item.id}
+                      id={item.id}
+                      toDoItem={item.toDoItem}
+                    />
+                  ) : (
+                    <Items
+                      key={item.id}
+                      id={item.id}
+                      toDoItem={item.toDoItem}
+                      isChecked={item.isChecked}
+                      toggleCompletion={toggleCompletion}
+                      inputRef={inputRef}
+                      updateItem={updateItem}
+                      saveItem={saveItem}
+                      todoItems={todoItems}
+                      deleteItem={deleteItem}
+                      postItem={postItem}
+                    />
+                  )
+                )}
+              {newItem && (
+                <li className="flex w-[95%] m-auto py-1 text-lg text-text_button">
+                  <div className="flex items-center justify-center w-[20rem]  ml-4">
+                    <button
+                      className={`w-7 h-7 rounded-full border-2 flex justify-center items-center "border-text_button`}
+                    >
+                      <span className="text-white ">✓</span>
+                    </button>
+                    <input
+                      placeholder="入力(フォーカスを外すと登録)"
+                      ref={inputRef} // useRefで作成したrefをここに設定
+                      type="text"
+                      value={postTodoTitle}
+                      onChange={(e) => setPostTodoTitle(e.target.value)}
+                      // onBlur={addPostNewItem}
+                      onBlur={() =>
+                        postTodoTitle.trim() === ""
+                          ? (setNewItem(false), setPostTodoTitle(""))
+                          : addPostNewItem()
+                      }
+                      className="px-2 py-1 border-b-2 w-[85%] focus:outline-none "
+                    />
+                  </div>
+                </li>
+              )}
+            </ul>
+          </SortableContext>
+        </DndContext>
+        <div className="w-full flex justify-end mr-4">
+          <button
+            className={` w-[55px] aspect-square fixed bottom-[145px] mr-3 rounded-full text-white text-[11px] ${
+              isSortMode ? "bg-trash_bg" : "bg-[#787878]"
+            }`}
+            onClick={() => setIsSortMode(!isSortMode)}
+          >
+            {isSortMode ? "完了" : "並べ替え"}
+          </button>
+        </div>
+        <PlusButton handleAddEvent={addEmptyItem} />
+        <Navigation />
+        <Toaster position="top-center" />
+      </div>
+    </>
   );
 };
 

--- a/src/app/(members)/todo/page.tsx
+++ b/src/app/(members)/todo/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState } from "react";
+import React from "react";
 import Tabs from "./_components/Tabs";
 import Navigation from "../../_components/Navigation";
 import Items from "./_components/Items";
@@ -44,8 +44,12 @@ const Page: React.FC = () => {
     setPostTodoTitle,
     addPostNewItem,
     updateTodoOrder,
+    clickSortMode,
+    isSortMode,
+
+    // setTempSortedItems,
   } = useTodo();
-  const [isSortMode, setIsSortMode] = useState(false);
+
   return (
     <>
       <div>
@@ -70,7 +74,12 @@ const Page: React.FC = () => {
             );
             const newIndex = todoItems.findIndex((item) => item.id === over.id);
             const sorted = arrayMove(todoItems, oldIndex, newIndex);
-            updateTodoOrder(sorted); // useTodo から取得済み
+            updateTodoOrder(
+              sorted.map((item, index) => ({
+                id: item.id,
+                sortOrder: index,
+              }))
+            ); // useTodo から取得済み
           }}
         >
           <SortableContext
@@ -80,6 +89,7 @@ const Page: React.FC = () => {
             <ul className="bg-white m-auto max-w-md w-[95%] pt-6 pb-16 min-h-svh">
               {todoItems
                 .filter((item) => item.todoGroupId === activeTabId)
+                .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0))
                 .map((item) =>
                   isSortMode ? (
                     <SortableItem
@@ -136,7 +146,8 @@ const Page: React.FC = () => {
             className={` w-[55px] aspect-square fixed bottom-[145px] mr-3 rounded-full text-white text-[11px] ${
               isSortMode ? "bg-trash_bg" : "bg-[#787878]"
             }`}
-            onClick={() => setIsSortMode(!isSortMode)}
+            // onClick={() => setIsSortMode(!isSortMode)}
+            onClick={() => clickSortMode()}
           >
             {isSortMode ? "完了" : "並べ替え"}
           </button>

--- a/src/app/(members)/todo/page.tsx
+++ b/src/app/(members)/todo/page.tsx
@@ -22,6 +22,7 @@ const Page: React.FC = () => {
     todoItems,
     postItem,
     newItem,
+    setNewItem,
     postTodoTitle,
     setPostTodoTitle,
     addPostNewItem,
@@ -67,7 +68,12 @@ const Page: React.FC = () => {
                 type="text"
                 value={postTodoTitle}
                 onChange={(e) => setPostTodoTitle(e.target.value)}
-                onBlur={addPostNewItem}
+                // onBlur={addPostNewItem}
+                onBlur={() =>
+                  postTodoTitle.trim() === ""
+                    ? (setNewItem(false), setPostTodoTitle(""))
+                    : addPostNewItem()
+                }
                 className="px-2 py-1 border-b-2 w-[85%] focus:outline-none "
               />
             </div>

--- a/src/app/_type/Todo.ts
+++ b/src/app/_type/Todo.ts
@@ -3,6 +3,7 @@ export interface TodoItem {
   id: number;
   toDoItem: string;
   isChecked: boolean;
+  sortOrder?: number;
 }
 
 export interface CreatePostRequestBody {
@@ -25,4 +26,9 @@ export type UpdateTodoItemRequestBody = TodoItem;
 export interface CreateResponse extends TodoItem {
   createdAt: Date;
   updatedAt: Date;
+}
+
+export interface SortedItem {
+  id: number;
+  sortOrder: number;
 }

--- a/src/app/_type/Todo.ts
+++ b/src/app/_type/Todo.ts
@@ -17,6 +17,7 @@ export interface CreateTodoItemRequestBody {
   todoGroupId: number | null;
   toDoItem: string;
   isChecked: boolean;
+  sortOrder?: number;
 }
 
 export type UpdateTodoItemRequestBody = TodoItem;

--- a/src/app/api/todo_group/[id]/todo_items/[itemId]/reorder/route.ts
+++ b/src/app/api/todo_group/[id]/todo_items/[itemId]/reorder/route.ts
@@ -1,0 +1,84 @@
+import { PrismaClient } from "@prisma/client";
+import { supabase } from "@/utils/supabase";
+import { NextResponse, NextRequest } from "next/server";
+
+const prisma = new PrismaClient();
+
+export const PUT = async (
+  request: NextRequest,
+  { params }: { params: { id: string } } // todoGroupId
+) => {
+  const token = request.headers.get("Authorization") ?? "";
+  const { data, error } = await supabase.auth.getUser(token);
+  if (error)
+    return NextResponse.json({ message: error.message }, { status: 400 });
+
+  const supabaseUserId = data.user.id;
+  const user = await prisma.users.findUnique({
+    where: { supabaseUserId },
+  });
+  if (!user)
+    return NextResponse.json(
+      { message: "ユーザーが見つかりません" },
+      { status: 404 }
+    );
+
+  const todoGroupId = parseInt(params.id, 10);
+  if (isNaN(todoGroupId)) {
+    return NextResponse.json(
+      { message: "todoGroupIdが無効です" },
+      { status: 400 }
+    );
+  }
+
+  const body = await request.json();
+  const { items }: { items: { id: number; sortOrder: number }[] } = body;
+
+  try {
+    const validTodoItems = await prisma.todoItems.findMany({
+      where: {
+        id: { in: items.map((item) => item.id) },
+        todoGroup: {
+          id: todoGroupId,
+          userId: user.id, // ここでユーザー所有を確認
+        },
+      },
+    });
+    const validIds = new Set(validTodoItems.map((item) => item.id));
+
+    // ② 有効なitemのみ更新
+    const updatePromises = items
+      .filter((item) => validIds.has(item.id))
+      .map((item) =>
+        prisma.todoItems.update({
+          where: { id: item.id },
+          data: { sortOrder: item.sortOrder },
+        })
+      );
+
+    await Promise.all(updatePromises);
+
+    return NextResponse.json({ status: "OK" });
+    // const updatePromises = items.map((item) =>
+    //   prisma.todoItems.update({
+    //     where: {
+    //       id: item.id,
+    //       todoGroup: {
+    //         id: todoGroupId,
+    //         user: { supabaseUserId },
+    //       },
+    //     },
+    //     data: { sortOrder: item.sortOrder },
+    //   })
+    // );
+
+    // await Promise.all(updatePromises);
+
+    // return NextResponse.json({ status: "OK" });
+  } catch (error) {
+    return NextResponse.json(
+      { message: "更新に失敗しました", error },
+      { status: 500 }
+    );
+  }
+};

--- a/src/app/api/todo_group/[id]/todo_items/route.ts
+++ b/src/app/api/todo_group/[id]/todo_items/route.ts
@@ -82,7 +82,7 @@ export const POST = async (
   }
   try {
     const body: CreateTodoItemRequestBody = await request.json();
-    const { toDoItem, isChecked } = body;
+    const { toDoItem, isChecked, sortOrder } = body;
 
     const todoGroup = await prisma.todoGroup.findUnique({
       where: {
@@ -102,6 +102,7 @@ export const POST = async (
         todoGroupId,
         toDoItem,
         isChecked,
+        sortOrder,
       },
     });
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -14,31 +14,7 @@ import Loading from "../loading";
 const Page = () => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-
   const router = useRouter();
-
-  // useEffect(() => {
-  //   const checkSession = async () => {
-  //     try {
-  //       const { data, error } = await supabase.auth.getSession();
-  //       if (error) {
-  //         console.error("セッション取得エラー:", error.message);
-  //         router.replace("/login");
-  //         return;
-  //       }
-  //       if (!data.session) {
-  //         console.error("セッション情報がありませんでした");
-  //         router.replace("/login");
-  //         return;
-  //       }
-  //       router.replace("/login/welcome");
-  //     } catch (error) {
-  //       console.error("セッション情報取得失敗:", error);
-  //       router.replace("/login");
-  //     }
-  //   };
-  //   checkSession();
-  // }, [router]);
 
   useEffect(() => {
     const checkSession = async () => {


### PR DESCRIPTION
todoリストの並べ替えを実装。
sortOrderをデータベースのTodoItemsに追加し、登録順にしていたものを並んでる順に表示させるように変更。
バックエンドはreorderフォルダ内にroute.tsを作成し、PUTを実装。
その他
・型の追加
　export interface SortedItem {
  id: number;
  sortOrder: number;
}
・リスト新規作成時もsortOrder番号の付与。