### PR TITLE
並び替えスマホの挙動改善

### DIFF
--- a/src/app/(members)/todo/page.tsx
+++ b/src/app/(members)/todo/page.tsx
@@ -12,6 +12,7 @@ import {
   closestCenter,
   KeyboardSensor,
   PointerSensor,
+  TouchSensor,
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
@@ -64,6 +65,13 @@ const Page: React.FC = () => {
             useSensor(PointerSensor),
             useSensor(KeyboardSensor, {
               coordinateGetter: sortableKeyboardCoordinates,
+            }),
+            // useSensorでスマホを使いやすく。
+            useSensor(TouchSensor, {
+              activationConstraint: {
+                delay: 150,
+                tolerance: 5,
+              },
             })
           )}
           collisionDetection={closestCenter}


### PR DESCRIPTION
スマホの並び替えがとてもやりづらかったため以下を追加。
todo/page.tsx内・・・TouchSensorを追加
  // useSensorでスマホを使いやすく。
            useSensor(TouchSensor, {
              activationConstraint: {
                delay: 150,
                tolerance: 5,
              },
            })