### PR TITLE
Feat/todo tab sorted order

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,8 +45,9 @@
         "postcss": "^8",
         "prisma": "^5.20.0",
         "tailwindcss": "^3.4.17",
+        "ts-node": "^10.9.2",
         "tsx": "^4.20.2",
-        "typescript": "^5"
+        "typescript": "^5.8.3"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -190,6 +191,30 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@dnd-kit/accessibility": {
@@ -1653,6 +1678,34 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/isomorphic-fetch": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.39.tgz",
@@ -1984,6 +2037,19 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ajv": {
@@ -2627,6 +2693,13 @@
         "node": ">= 6"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2845,6 +2918,16 @@
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/dlv": {
       "version": "1.1.3",
@@ -4838,6 +4921,13 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/map-age-cleaner": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
@@ -6601,6 +6691,57 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -6735,10 +6876,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
-      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6849,6 +6991,13 @@
       "version": "0.20201231.0",
       "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
       "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng=="
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/warning": {
       "version": "4.0.3",
@@ -7118,6 +7267,16 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "postcss": "^8",
     "prisma": "^5.20.0",
     "tailwindcss": "^3.4.17",
+    "ts-node": "^10.9.2",
     "tsx": "^4.20.2",
-    "typescript": "^5"
+    "typescript": "^5.8.3"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -94,7 +94,7 @@ model TodoItems {
   todoGroupId Int
   toDoItem    String
   isChecked   Boolean
-  sortOrder   Int?
+  sortOrder   Int
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -80,6 +80,7 @@ model TodoGroup {
   id             Int      @id @default(autoincrement())
   userId         Int
   toDoGroupTitle String
+  sortTabOrder   Int?
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
 

--- a/scripts/updateSortOrder.ts
+++ b/scripts/updateSortOrder.ts
@@ -1,31 +1,71 @@
-import { PrismaClient } from "@prisma/client";
+// import { PrismaClient } from "@prisma/client";
 
-const prisma = new PrismaClient();
+// const prisma = new PrismaClient();
+//TODOアイテムのソート順を更新するスクリプト
+// async function main() {
+//   const todoGroups = await prisma.todoGroup.findMany({
+//     include: {
+//       toDoItems: {
+//         orderBy: { createdAt: "asc" },
+//       },
+//     },
+//   });
 
-async function main() {
-  const todoGroups = await prisma.todoGroup.findMany({
-    include: {
-      toDoItems: {
-        orderBy: { createdAt: "asc" },
-      },
-    },
-  });
+//   for (const group of todoGroups) {
+//     for (let i = 0; i < group.toDoItems.length; i++) {
+//       const item = group.toDoItems[i];
+//       await prisma.todoItems.update({
+//         where: { id: item.id },
+//         data: { sortOrder: i + 1 },
+//       });
+//     }
+//   }
+// }
 
-  for (const group of todoGroups) {
-    for (let i = 0; i < group.toDoItems.length; i++) {
-      const item = group.toDoItems[i];
-      await prisma.todoItems.update({
-        where: { id: item.id },
-        data: { sortOrder: i + 1 },
-      });
-    }
-  }
-}
+// main()
+//   .catch((e) => {
+//     console.error("❌ Error:", e);
+//   })
+//   .finally(async () => {
+//     await prisma.$disconnect();
+//   });
 
-main()
-  .catch((e) => {
-    console.error("❌ Error:", e);
-  })
-  .finally(async () => {
-    await prisma.$disconnect();
-  });
+// ソートタブ順を付与するスクリプト
+//コマンド　npx tsx scripts/updateSortOrder.ts
+// const main = async () => {
+//   try {
+//     const todoGroups = await prisma.todoGroup.findMany({
+//       orderBy: [{ userId: "asc" }, { createdAt: "asc" }],
+//     });
+
+//     const updates = [];
+
+//     let currentUserId: number | null = null;
+//     let order = 1;
+
+//     for (const group of todoGroups) {
+//       if (group.userId !== currentUserId) {
+//         currentUserId = group.userId;
+//         order = 1;
+//       }
+
+//       updates.push(
+//         prisma.todoGroup.update({
+//           where: { id: group.id },
+//           data: { sortTabOrder: order },
+//         })
+//       );
+
+//       order++;
+//     }
+
+//     await prisma.$transaction(updates);
+//     console.log("✅ ユーザーごとに sortTabOrder を付与しました。");
+//   } catch (e) {
+//     console.error("❌ Error:", e);
+//   } finally {
+//     await prisma.$disconnect();
+//   }
+// };
+
+// main();

--- a/src/app/(members)/todo/_components/Tabs.tsx
+++ b/src/app/(members)/todo/_components/Tabs.tsx
@@ -231,9 +231,7 @@ const Tabs: React.FC<Props> = ({ todoGroups, activeTabId, setActiveTabId }) => {
                   <button
                     onClick={() => {
                       if (isSortMode) {
-                        // const sortedIds =
                         sortTabs.map((tab) => tab.id);
-                        clickSortTabMode();
                       }
                       clickSortTabMode();
                     }}
@@ -283,9 +281,7 @@ const Tabs: React.FC<Props> = ({ todoGroups, activeTabId, setActiveTabId }) => {
             <button
               onClick={() => {
                 if (isSortMode) {
-                  // const sortedIds =
                   sortTabs.map((tab) => tab.id);
-                  clickSortTabMode();
                 }
                 clickSortTabMode();
               }}

--- a/src/app/(members)/todo/_components/Tabs.tsx
+++ b/src/app/(members)/todo/_components/Tabs.tsx
@@ -221,11 +221,12 @@ const Tabs: React.FC<Props> = ({ todoGroups, activeTabId, setActiveTabId }) => {
                       className="w-full"
                     >
                       <button
-                        className={`w-full px-4 py-2 rounded-md text-left text-sm ${
-                          activeTabId === tab.id
-                            ? "bg-gray-800 text-white border-l-4 border-gray-600"
-                            : "bg-gray-700 text-gray-300"
-                        }`}
+                        // className={`w-full px-4 py-2 rounded-md text-left text-sm ${
+                        //   activeTabId === tab.id
+                        //     ? "bg-gray-800 text-white border-l-4 border-gray-600"
+                        //     : "bg-gray-700 text-gray-300"
+                        // }`}
+                        className="w-full px-4 py-2 rounded-md text-white text-left text-sm bg-text_button"
                         onClick={() => handleTabClick(tab.id)}
                       >
                         {tab.toDoGroupTitle}

--- a/src/app/(members)/todo/_components/Tabs.tsx
+++ b/src/app/(members)/todo/_components/Tabs.tsx
@@ -16,13 +16,11 @@ import {
   PointerSensor,
   useSensor,
   useSensors,
-  // DragEndEvent,
 } from "@dnd-kit/core";
 
 import {
   SortableContext,
   horizontalListSortingStrategy,
-  // arrayMove,
 } from "@dnd-kit/sortable";
 
 interface Props {
@@ -43,11 +41,11 @@ const Tabs: React.FC<Props> = ({ todoGroups, activeTabId, setActiveTabId }) => {
   const { handleMouseDown, handleMouseLeaveOrUp, handleMouseMove } =
     useMouseDrag(tabContainerRef);
   const {
-    updateTabOrder,
-    ToggleSortTabMode,
+    // updateTabOrder,
+    clickSortTabMode,
     sortTabs,
     isSortMode,
-    handleDragEnd,
+    handleTabDragEnd,
     setSortTabs,
   } = useControlTodoTab();
   // DnD sensors setup
@@ -199,7 +197,7 @@ const Tabs: React.FC<Props> = ({ todoGroups, activeTabId, setActiveTabId }) => {
         <DndContext
           sensors={sensors}
           collisionDetection={closestCenter}
-          onDragEnd={handleDragEnd}
+          onDragEnd={handleTabDragEnd}
         >
           <div
             className={`fixed inset-0 bg-[#787878aa] bg-opacity-40 flex items-center justify-center z-50 ${
@@ -221,11 +219,6 @@ const Tabs: React.FC<Props> = ({ todoGroups, activeTabId, setActiveTabId }) => {
                       className="w-full"
                     >
                       <button
-                        // className={`w-full px-4 py-2 rounded-md text-left text-sm ${
-                        //   activeTabId === tab.id
-                        //     ? "bg-gray-800 text-white border-l-4 border-gray-600"
-                        //     : "bg-gray-700 text-gray-300"
-                        // }`}
                         className="w-full px-4 py-2 rounded-md text-white text-left text-sm bg-text_button"
                         onClick={() => handleTabClick(tab.id)}
                       >
@@ -238,10 +231,11 @@ const Tabs: React.FC<Props> = ({ todoGroups, activeTabId, setActiveTabId }) => {
                   <button
                     onClick={() => {
                       if (isSortMode) {
-                        const sortedIds = sortTabs.map((tab) => tab.id);
-                        updateTabOrder(sortedIds);
+                        // const sortedIds =
+                        sortTabs.map((tab) => tab.id);
+                        clickSortTabMode();
                       }
-                      ToggleSortTabMode();
+                      clickSortTabMode();
                     }}
                     className="p-3 text-xs text-white bg-text_button rounded-md"
                   >
@@ -253,54 +247,6 @@ const Tabs: React.FC<Props> = ({ todoGroups, activeTabId, setActiveTabId }) => {
           </div>
         </DndContext>
       ) : (
-        // <DndContext
-        //   sensors={sensors}
-        //   collisionDetection={closestCenter}
-        //   onDragEnd={handleDragEnd}
-        // >
-        //   <div className="">
-        //     <SortableContext
-        //       items={sortTabs.map((tab) => tab.id)}
-        //       strategy={horizontalListSortingStrategy}
-        //     >
-        //       <div className="flex">
-        //         {sortTabs.map((tab) => (
-        //           <Sortable
-        //             key={tab.id}
-        //             id={tab.id}
-        //             isSortMode={true}
-        //             className="min-w-fit"
-        //           >
-        //             <button
-        //               // className={`min-w-fit px-4 py-2 rounded-custom-rounded ${
-        //               //   activeTabId === tab.id
-        //               //     ? "bg-gray-800 text-white border-t border-l border-r"
-        //               //     : "bg-gray-900"
-
-        //               // }`}
-        //               className="min-w-fit p-2 rounded-custom-rounded bg-gray-800 text-white border-t border-l border-r text-[13px]"
-        //               onClick={() => handleTabClick(tab.id)}
-        //             >
-        //               {tab.toDoGroupTitle}
-        //             </button>
-        //           </Sortable>
-        //         ))}
-        //       </div>
-        //     </SortableContext>
-        //     <button
-        //       onClick={() => {
-        //         if (isSortMode) {
-        //           const sortedIds = sortTabs.map((tab) => tab.id);
-        //           updateTabOrder(sortedIds);
-        //         }
-        //         ToggleSortTabMode();
-        //       }}
-        //       className="block p-2 min-w-fit text-white rounded-custom-rounded bg-text_button text-[11px]"
-        //     >
-        //       {isSortMode ? "並べ替え完了" : "並べ替え"}
-        //     </button>
-        //   </div>
-        // </DndContext>
         <div className="p-4 pb-0 max-w-md m-auto   rounded text-text_button">
           <div
             className="flex overflow-x-auto scrollbar-hide"
@@ -337,10 +283,11 @@ const Tabs: React.FC<Props> = ({ todoGroups, activeTabId, setActiveTabId }) => {
             <button
               onClick={() => {
                 if (isSortMode) {
-                  const sortedIds = sortTabs.map((tab) => tab.id);
-                  updateTabOrder(sortedIds);
+                  // const sortedIds =
+                  sortTabs.map((tab) => tab.id);
+                  clickSortTabMode();
                 }
-                ToggleSortTabMode();
+                clickSortTabMode();
               }}
               className="block p-2 min-w-fit text-white rounded-custom-rounded bg-text_button text-[11px]"
             >

--- a/src/app/(members)/todo/_hooks/useControlTodo.tsx
+++ b/src/app/(members)/todo/_hooks/useControlTodo.tsx
@@ -86,36 +86,40 @@ export const useTodo = () => {
   }, [fetcher, token]);
 
   //アクティブなタブの切り替え、情報を取得
-  useEffect(() => {
-    if (!token || activeTabId === null) return;
-    const fetchTodoItems = async () => {
-      try {
-        const response = await fetch(
-          `/api/todo_group/${activeTabId}/todo_items`,
-          {
-            headers: {
-              "Content-Type": "application/json",
-              Authorization: token!,
-            },
-          }
-        );
+  // useEffect(() => {
+  //   if (!token || activeTabId === null) return;
+  //   const fetchTodoItems = async () => {
+  //     try {
+  //       const response = await fetch(
+  //         `/api/todo_group/${activeTabId}/todo_items`,
+  //         {
+  //           headers: {
+  //             "Content-Type": "application/json",
+  //             Authorization: token!,
+  //           },
+  //         }
+  //       );
 
-        const data = await response.json();
-        if (response.ok) {
-          setTodoItems(data.todoItems);
-        } else {
-          console.error("Failed to fetch todo items:", data);
-        }
-      } catch (error) {
-        if (error instanceof Error) {
-          console.error(error.message);
-        }
-      } finally {
-        setLoading(false);
-      }
-    };
+  //       const data = await response.json();
+  //       if (response.ok) {
+  //         setTodoItems(data.todoItems);
+  //       } else {
+  //         console.error("Failed to fetch todo items:", data);
+  //       }
+  //     } catch (error) {
+  //       if (error instanceof Error) {
+  //         console.error(error.message);
+  //       }
+  //     } finally {
+  //       setLoading(false);
+  //     }
+  //   };
+  //   fetchTodoItems();
+  // }, [token, activeTabId]); // activeTabIdが変更されたときに実行
+  useEffect(() => {
+    if (!token || !activeTabId) return;
     fetchTodoItems();
-  }, [token, activeTabId]); // activeTabIdが変更されたときに実行
+  }, [token, activeTabId, fetchTodoItems]);
 
   //新しいアイテムが追加されたときにフォーカスを当てる
   useEffect(() => {

--- a/src/app/(members)/todo/_hooks/useControlTodo.tsx
+++ b/src/app/(members)/todo/_hooks/useControlTodo.tsx
@@ -199,6 +199,7 @@ export const useTodo = () => {
       todoGroupId: activeTabId,
       toDoItem: "",
       isChecked: false,
+      sortOrder: todoItems.length + 1, // 新しいアイテムのsortOrderを設定
     };
     try {
       // サーバーに新しいアイテムを送信

--- a/src/app/(members)/todo/_hooks/useControlTodoTab.tsx
+++ b/src/app/(members)/todo/_hooks/useControlTodoTab.tsx
@@ -1,0 +1,79 @@
+"use client";
+import { useState } from "react";
+import { arrayMove } from "@dnd-kit/sortable";
+import { DragEndEvent } from "@dnd-kit/core";
+import toast from "react-hot-toast";
+import { useSupabaseSession } from "@/app/_hooks/useSupabaseSession";
+import { SortedTab } from "@/app/_type/Todo";
+
+export const useControlTodoTab = () => {
+  const { token } = useSupabaseSession();
+  const [isSortMode, setIsSortMode] = useState(false);
+  const [sortTabs, setSortTabs] = useState<SortedTab[]>([]);
+
+  const handleTabDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = sortTabs.findIndex((tab) => tab.id === active.id);
+    const newIndex = sortTabs.findIndex((tab) => tab.id === over.id);
+    const newTabs = arrayMove(sortTabs, oldIndex, newIndex);
+    setSortTabs(newTabs); // 並び順を更新（ただし保存はモードOFF時）
+  };
+
+  const clickSortTabMode = async () => {
+    const isNowSortMode = isSortMode;
+    setIsSortMode(!isNowSortMode);
+    if (!isNowSortMode)
+      return toast(
+        <div>
+          <p className="pb-2">🏷️タブ並べ替えモード</p>
+
+          <p>ドラッグで並び替えられます</p>
+        </div>
+      );
+    if (!token) return toast.error("ログインしてください。");
+    const reorderedTabs = sortTabs.map((tab, index) => ({
+      id: tab.id,
+      sortTabOrder: index + 1,
+    }));
+    toast("🏷️ 並び替えモードを終了");
+    try {
+      const response = await fetch(`/api/todo_group/reorder`, {
+        method: "PUT",
+        headers: {
+          "content-type": "application/json",
+          Authorization: token,
+        },
+        body: JSON.stringify({ items: reorderedTabs }),
+      });
+      if (response.ok) {
+        setSortTabs((prev: SortedTab[]) =>
+          prev.map((tab) => {
+            const updated = reorderedTabs.find((r) => r.id === tab.id);
+            return updated
+              ? { ...tab, sortTabOrder: updated.sortTabOrder }
+              : tab;
+          })
+        );
+        toast.success("✅ 並び順を保存しました");
+      } else {
+        console.error("Failed to save tab order.");
+        // toast.error("❌ タブ並び順保存に失敗しました");
+        toast.error(`❌ タブ並び順保存に失敗しました（${response.status}）`);
+      }
+    } catch (e) {
+      console.error("Error updating tab order:", e);
+      toast.error("❌ サーバーエラーで順番を保存できませんでした");
+    }
+  };
+
+  return {
+    isSortMode,
+    clickSortTabMode,
+    setIsSortMode,
+    sortTabs,
+    setSortTabs,
+    handleTabDragEnd,
+  };
+};

--- a/src/app/(members)/todo/_hooks/useControlTodoTab.tsx
+++ b/src/app/(members)/todo/_hooks/useControlTodoTab.tsx
@@ -6,7 +6,7 @@ import toast from "react-hot-toast";
 import { useSupabaseSession } from "@/app/_hooks/useSupabaseSession";
 import { SortedTab } from "@/app/_type/Todo";
 
-export const useControlTodoTab = () => {
+export const useControlTodoTab = (fetchTabs?: () => void) => {
   const { token } = useSupabaseSession();
   const [isSortMode, setIsSortMode] = useState(false);
   const [sortTabs, setSortTabs] = useState<SortedTab[]>([]);
@@ -37,7 +37,7 @@ export const useControlTodoTab = () => {
       id: tab.id,
       sortTabOrder: index + 1,
     }));
-    toast("🏷️ 並び替えモードを終了");
+    //  toast("🏷️ 並び替えモードを終了");
     try {
       const response = await fetch(`/api/todo_group/reorder`, {
         method: "PUT",
@@ -57,6 +57,7 @@ export const useControlTodoTab = () => {
           })
         );
         toast.success("✅ 並び順を保存しました");
+        if (fetchTabs) fetchTabs();
       } else {
         console.error("Failed to save tab order.");
         // toast.error("❌ タブ並び順保存に失敗しました");

--- a/src/app/_components/PasswordInput.tsx
+++ b/src/app/_components/PasswordInput.tsx
@@ -1,4 +1,4 @@
-"use client";
+// "use client";
 
 import React, { useState } from "react";
 import Image from "next/image";

--- a/src/app/_components/Sortable.tsx
+++ b/src/app/_components/Sortable.tsx
@@ -48,7 +48,9 @@ export const Sortable: React.FC<Props> = ({
           isSortMode ? "cursor-grab active:cursor-grabbing" : ""
         } ${className}`}
       >
-        {isSortMode && (isDragging ? <FaRegHandRock /> : <FaRegHand />)}
+        <div className="text-indigo-500">
+          {isSortMode && (isDragging ? <FaRegHandRock /> : <FaRegHand />)}
+        </div>
         {children}
       </div>
     </>

--- a/src/app/_components/Sortable.tsx
+++ b/src/app/_components/Sortable.tsx
@@ -9,9 +9,15 @@ interface Props {
   id: number | string;
   children: React.ReactNode;
   className?: string;
+  isSortMode?: boolean; // 並べ替えモードかどうか
 }
 
-export const Sortable: React.FC<Props> = ({ id, children, className = "" }) => {
+export const Sortable: React.FC<Props> = ({
+  id,
+  children,
+  className = "",
+  isSortMode = false,
+}) => {
   const {
     attributes,
     listeners,
@@ -21,15 +27,27 @@ export const Sortable: React.FC<Props> = ({ id, children, className = "" }) => {
     isDragging,
   } = useSortable({ id });
   const style = { transform: CSS.Transform.toString(transform), transition };
+
+  // const style: React.CSSProperties = {
+  //   transform: CSS.Transform.toString(transform),
+  //   transition,
+  //   touchAction: "manipulation", // ← これ重要！
+  //   userSelect: isDragging ? "none" : "auto",
+  //   pointerEvents: isDragging ? "none" : "auto", // ← これも追加！
+  // };
+
   return (
     <>
-      {isDragging ? <FaRegHandRock /> : <FaRegHand />}
+      {isSortMode && (isDragging ? <FaRegHandRock /> : <FaRegHand />)}{" "}
       <div
         ref={setNodeRef}
         style={style}
         {...attributes}
-        {...listeners}
-        className={`cursor-grab active:cursor-grabbing touch-none ${className}`}
+        // 並べ替えモードのときだけリスナーを適用
+        {...(isSortMode ? listeners : {})}
+        className={`flex items-center gap-1 cursor-default ${
+          isSortMode ? "cursor-grab active:cursor-grabbing" : ""
+        } ${className}`}
       >
         {children}
       </div>

--- a/src/app/_components/Sortable.tsx
+++ b/src/app/_components/Sortable.tsx
@@ -38,17 +38,17 @@ export const Sortable: React.FC<Props> = ({
 
   return (
     <>
-      {isSortMode && (isDragging ? <FaRegHandRock /> : <FaRegHand />)}{" "}
       <div
         ref={setNodeRef}
         style={style}
         {...attributes}
         // 並べ替えモードのときだけリスナーを適用
         {...(isSortMode ? listeners : {})}
-        className={`flex items-center gap-1 cursor-default ${
+        className={`touch-none flex items-center gap-1 cursor-default ${
           isSortMode ? "cursor-grab active:cursor-grabbing" : ""
         } ${className}`}
       >
+        {isSortMode && (isDragging ? <FaRegHandRock /> : <FaRegHand />)}
         {children}
       </div>
     </>

--- a/src/app/_components/Sortable.tsx
+++ b/src/app/_components/Sortable.tsx
@@ -1,0 +1,38 @@
+"use Client";
+import React from "react";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { FaRegHand } from "react-icons/fa6";
+import { FaRegHandRock } from "react-icons/fa";
+
+interface Props {
+  id: number | string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export const Sortable: React.FC<Props> = ({ id, children, className = "" }) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id });
+  const style = { transform: CSS.Transform.toString(transform), transition };
+  return (
+    <>
+      {isDragging ? <FaRegHandRock /> : <FaRegHand />}
+      <div
+        ref={setNodeRef}
+        style={style}
+        {...attributes}
+        {...listeners}
+        className={`cursor-grab active:cursor-grabbing touch-none ${className}`}
+      >
+        {children}
+      </div>
+    </>
+  );
+};

--- a/src/app/_components/ToggleStartOfWeek.tsx
+++ b/src/app/_components/ToggleStartOfWeek.tsx
@@ -1,4 +1,4 @@
-"use client";
+// "use client";
 import React, { useCallback, useEffect } from "react";
 import toast, { Toaster } from "react-hot-toast";
 import Select from "react-select";

--- a/src/app/_type/Todo.ts
+++ b/src/app/_type/Todo.ts
@@ -1,24 +1,32 @@
+// todoGroup
+export interface CreatePostRequestBody {
+  userId: string;
+  id: number;
+  toDoGroupTitle: string;
+  sortTabOrder?: number;
+
+  createdAt: string;
+  updatedAt: string;
+}
+export interface SortedTab {
+  id: number;
+  sortTabOrder: number;
+  toDoGroupTitle: string;
+}
+
+// todoItem
 export interface TodoItem {
   todoGroupId: number;
   id: number;
   toDoItem: string;
   isChecked: boolean;
-  sortOrder?: number;
+  sortOrder: number;
 }
-
-export interface CreatePostRequestBody {
-  userId: string;
-  id: number;
-  toDoGroupTitle: string;
-  createdAt: string;
-  updatedAt: string;
-}
-
 export interface CreateTodoItemRequestBody {
   todoGroupId: number | null;
   toDoItem: string;
   isChecked: boolean;
-  sortOrder?: number;
+  sortOrder: number;
 }
 
 export type UpdateTodoItemRequestBody = TodoItem;

--- a/src/app/api/todo_group/[id]/todo_items/[itemId]/reorder/route.ts
+++ b/src/app/api/todo_group/[id]/todo_items/[itemId]/reorder/route.ts
@@ -33,7 +33,7 @@ export const PUT = async (
   }
 
   const body = await request.json();
-  const { items }: { items: { id: number; sortTabOrder: number }[] } = body;
+  const { items }: { items: { id: number; sortOrder: number }[] } = body;
 
   try {
     const validTodoItems = await prisma.todoItems.findMany({
@@ -53,7 +53,7 @@ export const PUT = async (
       .map((item) =>
         prisma.todoItems.update({
           where: { id: item.id },
-          data: { sortOrder: item.sortTabOrder },
+          data: { sortOrder: item.sortOrder },
         })
       );
 

--- a/src/app/api/todo_group/[id]/todo_items/[itemId]/reorder/route.ts
+++ b/src/app/api/todo_group/[id]/todo_items/[itemId]/reorder/route.ts
@@ -33,7 +33,7 @@ export const PUT = async (
   }
 
   const body = await request.json();
-  const { items }: { items: { id: number; sortOrder: number }[] } = body;
+  const { items }: { items: { id: number; sortTabOrder: number }[] } = body;
 
   try {
     const validTodoItems = await prisma.todoItems.findMany({
@@ -53,7 +53,7 @@ export const PUT = async (
       .map((item) =>
         prisma.todoItems.update({
           where: { id: item.id },
-          data: { sortOrder: item.sortOrder },
+          data: { sortOrder: item.sortTabOrder },
         })
       );
 

--- a/src/app/api/todo_group/reorder/route.ts
+++ b/src/app/api/todo_group/reorder/route.ts
@@ -1,0 +1,60 @@
+// api/todo_group/reorder.ts
+import { PrismaClient } from "@prisma/client";
+import { supabase } from "@/utils/supabase";
+import { NextResponse, NextRequest } from "next/server";
+
+const prisma = new PrismaClient();
+
+export const PUT = async (request: NextRequest) => {
+  const token = request.headers.get("Authorization") ?? "";
+  const { data, error } = await supabase.auth.getUser(token);
+  if (error)
+    return NextResponse.json({ message: error.message }, { status: 400 });
+  const supabaseUserId = data.user.id;
+  const user = await prisma.users.findUnique({ where: { supabaseUserId } });
+  if (!user)
+    return NextResponse.json(
+      { message: "ユーザーが見つかりません" },
+      { status: 404 }
+    );
+  const body = await request.json();
+  const items: { id: number; sortTabOrder: number }[] = body.items;
+
+  if (!Array.isArray(items)) {
+    return NextResponse.json(
+      { message: "無効なデータ形式です" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    // ③ 自分のタブのうち、更新対象になっているものだけを取得
+    const validGroups = await prisma.todoGroup.findMany({
+      where: {
+        id: { in: items.map((tab) => tab.id) },
+        userId: user.id,
+      },
+    });
+
+    const validIds = new Set(validGroups.map((group) => group.id));
+
+    const updatePromises = items
+      .filter((tab) => validIds.has(tab.id))
+      .map((tab) =>
+        prisma.todoGroup.update({
+          where: { id: tab.id },
+          data: { sortTabOrder: tab.sortTabOrder },
+        })
+      );
+
+    await Promise.all(updatePromises);
+
+    return NextResponse.json({ status: "OK" });
+  } catch (error) {
+    console.error("❌ タブ順更新エラー:", error);
+    return NextResponse.json(
+      { message: "タブ順の更新に失敗しました", error: String(error) },
+      { status: 500 }
+    );
+  }
+};

--- a/src/app/api/todo_group/route.ts
+++ b/src/app/api/todo_group/route.ts
@@ -20,7 +20,7 @@ export const GET = async (request: Request) => {
   try {
     const todoGroups = await prisma.todoGroup.findMany({
       where: { userId: user.id },
-      orderBy: { createdAt: "asc" },
+      orderBy: { sortTabOrder: "asc" },
     });
     return NextResponse.json({ status: "OK", todoGroups });
   } catch (error) {


### PR DESCRIPTION
タブの並び替え実装。
スキーマを変更（オプショナル）→npx prisma db push→npx prisma generate →列はできたが、すでにあるタブはnullのため、script（updateSortOrder）でユーザーごとにsortTabOrder番号を付与。→バックエンド作成。/api/todo_group/reorder
タブの型をフロントと合わせて作成。